### PR TITLE
Fix CI build

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -17,7 +17,9 @@ jobs:
       - run: |
           python -m venv .venv
           source .venv/bin/activate
-          pip install -r requirements.txt
+          pip install uv
+          uv pip compile --extra=dev pyproject.toml -o requirements.txt
+          uv pip sync requirements.txt
 
       - run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -2,7 +2,7 @@ name: Style
 
 on:
   pull_request:
-    branches: [ release ]
+    branches: [ main ]
 
 jobs:
   check:


### PR DESCRIPTION
A couple of copy/paste errors on the CI build:
1. Needs to run on PRs to `main` instead of `release`
2. Needs to generate the `requirements.txt`, since we don't want that checked into the repo.