### PR TITLE
ci: run unit tests on PR

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -1,0 +1,43 @@
+name: PR Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      # setup the repository
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
+      - run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install uv
+          uv pip compile --extra=dev pyproject.toml -o requirements.txt
+          uv pip sync requirements.txt
+
+      - run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
+
+      - run: pytest tests/ --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml --cov=recommence --cov-report=html:coverage/cov-${{ matrix.os }}-${{ matrix.python-version }}.html
+
+      - name: Upload pytest test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-results-${{ matrix.os }}-${{ matrix.python-version }}
+          path: |
+            junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml
+            coverage/cov-${{ matrix.os }}-${{ matrix.python-version }}.html
+
+          # Use always() to always run this step to publish test results when there are test failures
+        if: ${{ always() }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ classifiers = [
 dev = [
     "pip",
     "ruff",
+    "pytest",
+    "pytest-cov",
     "pyright",
     "commitizen",
     "pre-commit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,9 @@ description = ""
 authors = [
     {name = "Andy Patterson", email = "andrew.patterson@amii.ca"},
 ]
-dependencies = []
+dependencies = [
+    "numpy>=1.20,<=2.1",
+]
 requires-python = ">=3.10,<3.13"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Adds a simple github actions workflow to run the testing infrastructure whenever a PR is opened against `main`.

Tests on macos and ubuntu with python versions 3.10 - 3.12