### PR TITLE
Staging Area

### DIFF
--- a/recommence/Config.py
+++ b/recommence/Config.py
@@ -3,6 +3,19 @@ from dataclasses import dataclass
 @dataclass
 class CheckpointConfig:
     save_path: str
+    staging_path: str | None = None
     data_file: str = 'data.pkl'
 
     no_fail: bool = False
+
+    def should_stage(self) -> bool:
+        return self.staging_path is not None
+
+    def get_staging_path(self) -> str:
+        if self.staging_path is not None:
+            return self.staging_path
+
+        return self.save_path
+
+    def get_staging_data_path(self) -> str:
+        return f'{self.get_staging_path()}/{self.data_file}'

--- a/recommence/Config.py
+++ b/recommence/Config.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+@dataclass
+class CheckpointConfig:
+    save_path: str
+    data_file: str = 'data.pkl'
+
+    no_fail: bool = False

--- a/recommence/_utils/compress.py
+++ b/recommence/_utils/compress.py
@@ -1,0 +1,23 @@
+import os
+import tarfile
+from glob import glob
+
+def compress_dir(input: str, target: str):
+    os.makedirs(target, exist_ok=True)
+    tar = tarfile.open(target + ".tar.xz", mode='w:xz')
+
+    sub_files = glob(f'{input}/**', recursive=True)
+
+    for f in sub_files:
+        if os.path.isdir(f): continue
+
+        name = f.replace(f'{input}/', '')
+        tar.add(f, arcname=name)
+
+    tar.close()
+
+def uncompress_dir(input: str, target: str):
+    os.makedirs(target, exist_ok=True)
+    tar = tarfile.open(input + '.tar.xz', mode='r:xz')
+    tar.extractall(target)
+    tar.close()

--- a/recommence/_utils/pickle.py
+++ b/recommence/_utils/pickle.py
@@ -1,0 +1,14 @@
+import pickle
+import logging
+
+logger = logging.getLogger('recommence')
+
+def read_pickle(path: str, no_fail: bool):
+    try:
+        with open(path, 'rb') as f:
+            return pickle.load(f)
+
+    except Exception as e:
+        logger.exception(f'Failed to load checkpoint at {path}')
+        if not no_fail:
+            raise e

--- a/tests/RL_loop_test.py
+++ b/tests/RL_loop_test.py
@@ -1,4 +1,4 @@
-from recommence.Checkpoint import Checkpoint
+from recommence.Checkpoint import Checkpoint, CheckpointConfig
 from tests._utils.TileCodingAgent import TileCodingAgent
 from RlGlue import RlGlue, BaseEnvironment
 import gymnasium
@@ -40,7 +40,10 @@ class CartpoleEnvironment(BaseEnvironment):
 
 
 def run_rl_system(seed: int, should_chk: bool, tmp_path) -> Tuple[np.ndarray, ReturnCollector]:
-    chk = Checkpoint(str(tmp_path)) if should_chk else FakeCheckpoint()
+    config = CheckpointConfig(
+        save_path=str(tmp_path),
+    )
+    chk = Checkpoint(config) if should_chk else FakeCheckpoint()
 
     agent = chk.register('agent', lambda: TileCodingAgent())
     env = chk.register("env", lambda: CartpoleEnvironment(seed=42))
@@ -65,7 +68,7 @@ def run_rl_system(seed: int, should_chk: bool, tmp_path) -> Tuple[np.ndarray, Re
             chk.save()
             del chk
 
-            chk = Checkpoint(tmp_path)
+            chk = Checkpoint(config)
             agent = chk['agent']
             env = chk['env']
             glue = chk['glue']
@@ -85,6 +88,3 @@ def test_RL_integration(tmp_path):
 
   assert np.all(no_chk_result[0] == chk_result[0])
   assert np.all(no_chk_result[1].get() == chk_result[1].get())
-
-
-

--- a/tests/acceptance_test.py
+++ b/tests/acceptance_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+import shutil
 from recommence.Checkpoint import Checkpoint, CheckpointConfig
 
 class FakeAgent:
@@ -23,6 +24,31 @@ def test_checkpoint1(tmp_path):
 
     chk = Checkpoint(config)
 
+    loaded_agent = chk['agent']
+
+    assert id(original_agent) != id(loaded_agent)
+    assert np.all(original_agent.weights == loaded_agent.weights)
+    assert original_agent.steps == loaded_agent.steps
+
+    chk.remove()
+
+
+def test_checkpoint2(tmp_path):
+    config = CheckpointConfig(
+        save_path=str(tmp_path / 'dest'),
+        staging_path=str(tmp_path / 'stage'),
+    )
+    chk = Checkpoint(config)
+
+    chk['agent'] = lambda: FakeAgent()
+    original_agent = chk['agent']
+    original_agent.weights[0] = 1
+
+    chk.save()
+    del chk
+    shutil.rmtree(tmp_path / 'stage')
+
+    chk = Checkpoint(config)
     loaded_agent = chk['agent']
 
     assert id(original_agent) != id(loaded_agent)

--- a/tests/acceptance_test.py
+++ b/tests/acceptance_test.py
@@ -1,5 +1,5 @@
 import numpy as np
-from recommence.Checkpoint import Checkpoint
+from recommence.Checkpoint import Checkpoint, CheckpointConfig
 
 class FakeAgent:
     def __init__(self):
@@ -7,7 +7,10 @@ class FakeAgent:
         self.steps = 1
 
 def test_checkpoint1(tmp_path):
-    chk = Checkpoint(save_path=str(tmp_path))
+    config = CheckpointConfig(
+        save_path=str(tmp_path),
+    )
+    chk = Checkpoint(config)
 
     chk['agent'] = lambda: FakeAgent()
     original_agent = chk['agent']
@@ -18,7 +21,7 @@ def test_checkpoint1(tmp_path):
     chk.save()
     del chk
 
-    chk = Checkpoint(save_path=str(tmp_path))
+    chk = Checkpoint(config)
 
     loaded_agent = chk['agent']
 
@@ -27,7 +30,3 @@ def test_checkpoint1(tmp_path):
     assert original_agent.steps == loaded_agent.steps
 
     chk.remove()
-
-
-
-

--- a/tests/register_test.py
+++ b/tests/register_test.py
@@ -1,5 +1,5 @@
 import numpy as np
-from recommence.Checkpoint import Checkpoint
+from recommence.Checkpoint import Checkpoint, CheckpointConfig
 
 
 class Agent:
@@ -8,7 +8,10 @@ class Agent:
         self.steps = 1
 
 def test_checkpoint_register(tmp_path):
-    chk = Checkpoint(save_path=str(tmp_path))
+    config = CheckpointConfig(
+        save_path=str(tmp_path),
+    )
+    chk = Checkpoint(config)
 
     registered_agent = chk.register('agent', lambda: Agent())
 
@@ -18,7 +21,7 @@ def test_checkpoint_register(tmp_path):
     chk.save()
     del chk
 
-    chk = Checkpoint(save_path=str(tmp_path))
+    chk = Checkpoint(config)
 
     loaded_agent = chk['agent']
 


### PR DESCRIPTION
This PR adds a staging area for checkpoints. For most HPC clusters, writing to a local ssd will be multiple orders of magnitude faster than writing to the shared filesystem. We'll use that local ssd as a buffer to write out the initial checkpoint, then move the checkpoint to shared storage over the network. In the process, we can compress the checkpoint aggressively (`pickle`-based checkpoints should be highly compressible).

Ideally, this transfer from buffer->shared storage should be done in the background off of the hot-path. Currently, this PR does not deal with that asynchrony.